### PR TITLE
Update composer php requirement to 5.5 and up

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.2"
+        "php": "~5.5|~7.0"
     },
     "require-dev": {
         "react/event-loop": "0.3.*@dev"


### PR DESCRIPTION
PHP 5.5 is the oldest still supported PHP version. It does not make
sense to support older versions. PHP 7 will be released soon, so let's
start explicitly supporting it.

Fixes #7 